### PR TITLE
removed unused import, fixes test compilation

### DIFF
--- a/porterstemmer_fixes_test.go
+++ b/porterstemmer_fixes_test.go
@@ -3,7 +3,6 @@ package porterstemmer
 
 
 import (
-	"fmt"
 	"testing"
 )
 


### PR DESCRIPTION
prior to this I get:

```
$ go test -v
# github.com/reiver/go-porterstemmer
./porterstemmer_fixes_test.go:6: imported and not used: "fmt"
FAIL	github.com/reiver/go-porterstemmer [build failed]
```