### PR TITLE
Fix panics

### DIFF
--- a/porterstemmer.go
+++ b/porterstemmer.go
@@ -789,8 +789,10 @@ func step5a(s []rune) []rune {
 
 			if 1 < m {
 				result = subSlice
-			} else if c := subSlice[len(subSlice)-1] ; 1 == m && !( hasConsonantVowelConsonantSuffix(subSlice) && 'w' != c && 'x' != c && 'y' != c)  {
-				result = subSlice
+			} else if 1 == m {
+					if c := subSlice[len(subSlice)-1] ; !( hasConsonantVowelConsonantSuffix(subSlice) && 'w' != c && 'x' != c && 'y' != c)  {
+					result = subSlice
+				}
 			}
 		}
 

--- a/porterstemmer_fixes_test.go
+++ b/porterstemmer_fixes_test.go
@@ -3,7 +3,6 @@ package porterstemmer
 
 
 import (
-	"fmt"
 	"testing"
 )
 

--- a/porterstemmer_fuzz_test.go
+++ b/porterstemmer_fuzz_test.go
@@ -1,0 +1,59 @@
+package porterstemmer
+
+import (
+	"bytes"
+	"testing"
+)
+
+const maxFuzzLen = 6
+
+// Test inputs of English characters less than maxFuzzLen
+// Added to help diagnose https://github.com/reiver/go-porterstemmer/issues/4
+func TestStemFuzz(t *testing.T) {
+
+	input := []byte{'a'}
+	for len(input) < maxFuzzLen {
+		// test input
+
+		panicked := false
+		func() {
+			defer func() { panicked = recover() != nil }()
+			StemString(string(input))
+		}()
+		if panicked {
+			t.Errorf("StemString panicked for input '%s'", input)
+		}
+
+		// if all z's extend
+		if allZs(input) {
+			input = bytes.Repeat([]byte{'a'}, len(input)+1)
+		} else {
+			// increment
+			input = incrementBytes(input)
+		}
+	}
+}
+
+func incrementBytes(in []byte) []byte {
+        rv := make([]byte, len(in))
+        copy(rv, in)
+        for i := len(rv) - 1; i >= 0; i-- {
+                if rv[i]+1 == '{' {
+                        rv[i] = 'a'
+                        continue
+                }
+                rv[i] = rv[i] + 1
+                break
+
+        }
+        return rv
+}
+
+func allZs(in []byte) bool {
+        for _, b := range in {
+                if b != 'z' {
+                        return false
+                }
+        }
+        return true
+}


### PR DESCRIPTION
This pull-request is related to issue #4 

Added a fuzz unit test to identify which inputs (less than 6 chars long) result in a panic.
Moved check for measure = 1 before creating slice to avoid panic in rule 5a.