### PR TITLE
Update porterstemmer.go

### DIFF
--- a/porterstemmer.go
+++ b/porterstemmer.go
@@ -784,7 +784,9 @@ func step5a(s []rune) []rune {
 			lenSuffix := 1
 
 			subSlice := s[:lenS-lenSuffix]
-
+			if len(subSlice) == 0 {
+				return result
+			}
 			m := measure(subSlice)
 
 			if 1 < m {


### PR DESCRIPTION
fix crash on some not valid english words such as "eeg", which will cause a index out range exception.